### PR TITLE
#737 use ClusterIP instead of LoadBalancer for service type

### DIFF
--- a/onboarding-carts/values_carts.yaml
+++ b/onboarding-carts/values_carts.yaml
@@ -5,7 +5,7 @@ image:
     pullPolicy: IfNotPresent
 service:
     name: carts
-    type: LoadBalancer
+    type: ClusterIP
     externalPort: 80
     internalPort: 8080
 container:


### PR DESCRIPTION
When using LoadBalancer we have the risk of not receiving an external IP for the service (which we don't need anyway because we expose it via Istio VirtualServices), and the helm upgrade --wait command will time out