### PR TITLE
#1086 increase cpu limits

### DIFF
--- a/onboarding-carts/carts/templates/deployment.yaml
+++ b/onboarding-carts/carts/templates/deployment.yaml
@@ -62,8 +62,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-              cpu: 500m
+              cpu: 1000m
               memory: 2048Mi
           requests:
-              cpu: 250m
+              cpu: 500m
               memory: 1024Mi

--- a/onboarding-carts/carts/values.yaml
+++ b/onboarding-carts/carts/values.yaml
@@ -1,2 +1,2 @@
-image: docker.io/keptnexamples/carts:0.9.1
+image: docker.io/keptnexamples/carts:0.10.1
 replicaCount: 1


### PR DESCRIPTION
- Increased cpu limits to reduce restart loops as the service took 90 seconds to start
- Change image version/tag to 0.10.1