### PR TITLE
Added strategy type recreate for database

### DIFF
--- a/unleash-server/unleash-db/templates/db-deployment.yaml
+++ b/unleash-server/unleash-db/templates/db-deployment.yaml
@@ -30,6 +30,8 @@ metadata:
   name: unleash-db
 spec:
   replicas: {{ .Values.replicaCount }}
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app: unleash-db


### PR DESCRIPTION
If we edit the deployment (e.g., by sending a new-artifact with deployment-strategy=direct-deployment) Kubernetes will create a new pod and wait for the new pod to be ready before the old pod will be removed.
This behaviour is not desireable for postgres with a Persistent Volume Claim (PVC), as acquiring the PVC is blocking and the new pod will never come up.

This change fixes this behaviour. We also have the very same setting in carts-db:
https://github.com/keptn/examples/blob/a45849655fd76325fe2e8101a7456f271452b5da/onboarding-carts/carts-db/templates/carts-db-deployment.yaml#L22-L23