### PR TITLE
StorageClassName=standard definition is not needed

### DIFF
--- a/unleash-server/unleash-db/templates/db-deployment.yaml
+++ b/unleash-server/unleash-db/templates/db-deployment.yaml
@@ -6,7 +6,6 @@ metadata:
   labels:
     app: unleash
 spec:
-  storageClassName: standard
   accessModes:
     - ReadWriteOnce
   resources:


### PR DESCRIPTION
The StorageClassName=standard definition is not needed, it might fail in K8s versions when finding the default class leading to unbound PVC and to failed PoD deployment.