### PR TITLE
#1495 Add default values to SLO config

### DIFF
--- a/onboarding-carts/slo-quality-gates.yaml
+++ b/onboarding-carts/slo-quality-gates.yaml
@@ -1,11 +1,13 @@
 ---
-spec_version: '0.1.1'
+spec_version: "0.1.1"
 comparison:
   compare_with: "single_result"
   include_result_with_score: "pass"
-  aggregate_function: avg
+  aggregate_function: "avg"
+  number_of_comparison_results: 1
 objectives:
-  - sli: response_time_p95
+  - sli: "response_time_p95"
+    key_sli: false
     pass:             # pass if (relative change <= 10% AND absolute value is < 600ms)
       - criteria:
           - "<=+10%"  # relative values require a prefixed sign (plus or minus)

--- a/onboarding-carts/slo-self-healing.yaml
+++ b/onboarding-carts/slo-self-healing.yaml
@@ -1,18 +1,20 @@
 ---
-spec_version: '0.1.1'
+spec_version: "0.1.1"
 comparison:
   compare_with: "single_result"
   include_result_with_score: "pass"
-  aggregate_function: avg
+  aggregate_function: "avg"
+  number_of_comparison_results: 1
 objectives:
-  - sli: response_time_p90
-    pass:        # pass if (relative change <= 10% AND absolute value is < 500)
+  - sli: "response_time_p90"
+    key_sli: false
+    pass:             # pass if (relative change <= 10% AND absolute value is < 1000)
       - criteria:
-          - "<=+10%" # relative values require a prefixed sign (plus or minus)
+          - "<=+10%"  # relative values require a prefixed sign (plus or minus)
           - "<1000"   # absolute values only require a logical operator
-    warning:     # if the response time is below 800ms, the result should be a warning
+    warning:          # if the response time is below 1200ms, the result should be a warning
       - criteria:
           - "<=1200"
 total_score:
   pass: "90%"
-  warning: 40%
+  warning: "40%"


### PR DESCRIPTION
Added the default values `key_sli: false` and `number_of_comparison_results: 1` to the SLO configs. 