### PR TITLE
Added kubernetes recommended labels to carts and carts-db deployment manifest

### DIFF
--- a/onboarding-carts/carts-db/templates/carts-db-deployment.yaml
+++ b/onboarding-carts/carts-db/templates/carts-db-deployment.yaml
@@ -29,6 +29,11 @@ spec:
       labels:
         app: carts-db
         deployment: carts-db
+        app.kubernetes.io/name: {{ .Values.keptn.service }}
+        app.kubernetes.io/instance: "{{ .Values.keptn.service }}-{{ .Values.keptn.deployment }}"
+        app.kubernetes.io/component: database
+        app.kubernetes.io/part-of: "{{ .Values.keptn.project }}"
+        app.kubernetes.io/managed-by: Keptn
     spec:
       containers:
       - name: carts-db 

--- a/onboarding-carts/carts/templates/deployment.yaml
+++ b/onboarding-carts/carts/templates/deployment.yaml
@@ -16,6 +16,11 @@ spec:
     metadata: 
       labels:
         app: carts
+        app.kubernetes.io/name: {{ .Values.keptn.service }}
+        app.kubernetes.io/instance: "{{ .Values.keptn.service }}-{{ .Values.keptn.deployment }}"
+        app.kubernetes.io/component: api
+        app.kubernetes.io/part-of: "{{ .Values.keptn.project }}"
+        app.kubernetes.io/managed-by: Keptn
     spec:
       containers:
       - name: carts


### PR DESCRIPTION
This implements #91 and adds some recommended K8s labels to the deployment manifest.

For instance, the carts deployment (and the pod) now has the following labels:

```
apiVersion: extensions/v1beta1
kind: Deployment
metadata:
  name: carts
  namespace: sockshop-production
spec:
  replicas: 1
  selector:
    matchLabels:
      app: carts
  strategy:
    rollingUpdate:
      maxSurge: 25%
      maxUnavailable: 0
    type: RollingUpdate
  template:
    metadata:
      creationTimestamp: null
      labels:
        app: carts
        app.kubernetes.io/component: api
        app.kubernetes.io/instance: carts-canary
        app.kubernetes.io/managed-by: Keptn
        app.kubernetes.io/name: carts
        app.kubernetes.io/part-of: sockshop
    spec:
      containers:
      - env:
        - name: DT_CUSTOM_PROP
          value: keptn_project=sockshop keptn_service=carts keptn_stage=production
            keptn_deployment=canary
        image: docker.io/keptnexamples/carts:0.11.1
        imagePullPolicy: IfNotPresent

```