### PR TITLE
#101 Update K8s manifest apiVersion to apps/v1 to be compatible with K8s 1.16+

### DIFF
--- a/load-generation/cartsloadgen/deploy/cartsloadgen-base.yaml
+++ b/load-generation/cartsloadgen/deploy/cartsloadgen-base.yaml
@@ -4,7 +4,7 @@ kind: Namespace
 metadata:
   name: loadgen
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: cartsloadgen

--- a/load-generation/cartsloadgen/deploy/cartsloadgen-fast.yaml
+++ b/load-generation/cartsloadgen/deploy/cartsloadgen-fast.yaml
@@ -4,7 +4,7 @@ kind: Namespace
 metadata:
   name: loadgen
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: cartsloadgen

--- a/load-generation/cartsloadgen/deploy/cartsloadgen-faulty.yaml
+++ b/load-generation/cartsloadgen/deploy/cartsloadgen-faulty.yaml
@@ -4,7 +4,7 @@ kind: Namespace
 metadata:
   name: loadgen
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: cartsloadgen

--- a/onboarding-carts/argo/carts/templates/carts-db-deployment.yaml
+++ b/onboarding-carts/argo/carts/templates/carts-db-deployment.yaml
@@ -11,7 +11,7 @@ spec:
       storage: 100Mi
 status: {}
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: carts-db

--- a/onboarding-carts/carts-db/templates/carts-db-deployment.yaml
+++ b/onboarding-carts/carts-db/templates/carts-db-deployment.yaml
@@ -11,7 +11,7 @@ spec:
       storage: 100Mi
 status: {}
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: carts-db

--- a/onboarding-carts/manifests/manifest-carts-db.yaml
+++ b/onboarding-carts/manifests/manifest-carts-db.yaml
@@ -12,7 +12,7 @@ spec:
       storage: 100Mi
 status: {}
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: carts-db

--- a/onboarding-carts/manifests/manifest-carts.yaml
+++ b/onboarding-carts/manifests/manifest-carts.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: carts

--- a/unleash-server/unleash-db/templates/db-deployment.yaml
+++ b/unleash-server/unleash-db/templates/db-deployment.yaml
@@ -23,7 +23,7 @@ data:
   POSTGRES_USER: postgres
   POSTGRES_PASSWORD: somepassword
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: unleash-db

--- a/unleash-server/unleash/templates/deployment.yaml
+++ b/unleash-server/unleash/templates/deployment.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: unleash


### PR DESCRIPTION
Fixes #101 

This PR updates to Kubernetes Manifests from apiVersion v1beta to `apps/v1`.

This ensures our examples are compatible with newer K8s versions.