### PR TITLE
fix missing canary tag for bluegreen deployment SLI

### DIFF
--- a/onboarding-carts/sli-config-prometheus-bg.yaml
+++ b/onboarding-carts/sli-config-prometheus-bg.yaml
@@ -1,0 +1,6 @@
+---
+spec_version: '1.0'
+indicators:
+  response_time_p50: histogram_quantile(0.5, sum by(le) (rate(http_response_time_milliseconds_bucket{handler="ItemsController.addToCart",job="$SERVICE-$PROJECT-$STAGE-canary"}[$DURATION_SECONDS])))
+  response_time_p90: histogram_quantile(0.9, sum by(le) (rate(http_response_time_milliseconds_bucket{handler="ItemsController.addToCart",job="$SERVICE-$PROJECT-$STAGE-canary"}[$DURATION_SECONDS])))
+  response_time_p95: histogram_quantile(0.95, sum by(le) (rate(http_response_time_milliseconds_bucket{handler="ItemsController.addToCart",job="$SERVICE-$PROJECT-$STAGE-canary"}[$DURATION_SECONDS])))

--- a/onboarding-carts/sli-config-prometheus.yaml
+++ b/onboarding-carts/sli-config-prometheus.yaml
@@ -1,6 +1,0 @@
----
-spec_version: '1.0'
-indicators:
-  response_time_p50: histogram_quantile(0.5, sum by(le) (rate(http_response_time_milliseconds_bucket{handler="ItemsController.addToCart",job="$SERVICE-$PROJECT-$STAGE"}[$DURATION_SECONDS])))
-  response_time_p90: histogram_quantile(0.9, sum by(le) (rate(http_response_time_milliseconds_bucket{handler="ItemsController.addToCart",job="$SERVICE-$PROJECT-$STAGE"}[$DURATION_SECONDS])))
-  response_time_p95: histogram_quantile(0.95, sum by(le) (rate(http_response_time_milliseconds_bucket{handler="ItemsController.addToCart",job="$SERVICE-$PROJECT-$STAGE"}[$DURATION_SECONDS])))


### PR DESCRIPTION
The `-canary` filter was missing and thus the metrics for the wrong version got pulled.
needed for: https://github.com/keptn/tutorials/issues/91 

Signed-off-by: jetzlstorfer <juergen.etzlstorfer@dynatrace.com>