### PR TITLE
Remove kubectl deprecated warning

### DIFF
--- a/istio-configuration/configure-istio.sh
+++ b/istio-configuration/configure-istio.sh
@@ -55,7 +55,7 @@ echo "Waiting a little bit"
 sleep 10
 
 # Creating Keptn ingress config map
-kubectl create configmap -n keptn ingress-config --from-literal=ingress_hostname_suffix=$(kubectl -n keptn get ingress api-keptn-ingress -ojsonpath='{.spec.rules[0].host}') --from-literal=ingress_port=80 --from-literal=ingress_protocol=http --from-literal=istio_gateway=public-gateway.istio-system -oyaml --dry-run | kubectl apply -f -
+kubectl create configmap -n keptn ingress-config --from-literal=ingress_hostname_suffix=$(kubectl -n keptn get ingress api-keptn-ingress -ojsonpath='{.spec.rules[0].host}') --from-literal=ingress_port=80 --from-literal=ingress_protocol=http --from-literal=istio_gateway=public-gateway.istio-system -oyaml --dry-run=client | kubectl apply -f -
 
 # Restart helm service
 kubectl delete pod -n keptn -lapp.kubernetes.io/name=helm-service


### PR DESCRIPTION
Changed config map command to remove kubectl deprecated warning.

The ```--dry-run``` parameter is going to be deprecated and should be replaced with ```--dry-run=client```.