### PR TITLE
Update istio ingress API version

### DIFF
--- a/istio-configuration/configure-istio.sh
+++ b/istio-configuration/configure-istio.sh
@@ -19,7 +19,7 @@ echo "External IP for istio-ingressgateway is ${INGRESS_IP}, creating configmaps
 
 # Applying ingress-manifest
 kubectl apply -f - <<EOF
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:


### PR DESCRIPTION
The current API version used to create the Istio ingress manifest is being deprecated and therefore needs to be replaced to work with newer versions of kubectl.

![networking-k8s deprecation](https://user-images.githubusercontent.com/40315960/121368987-c6c53b00-c93b-11eb-902b-e4236def6c3f.png)

