### PR TITLE
fix: Remove v prefix in version tags for automated releases

### DIFF
--- a/.versionrc.json
+++ b/.versionrc.json
@@ -3,6 +3,7 @@
   "scripts": {
     "postchangelog": "./gh-actions-scripts/post-changelog-actions.sh"
   },
+  "tagPrefix": "",
   "types": [
     {
       "type": "feat",


### PR DESCRIPTION
#### This PR
* removes the `v` version tag prefix from the automated release config to follow the scheme of previous releases