### PR TITLE
fix: change SLO values for new podtatohead image

### DIFF
--- a/quickstart/demo/slo.yaml
+++ b/quickstart/demo/slo.yaml
@@ -9,10 +9,10 @@ objectives:
     displayName: "HTTP Respone Time"
     pass:
       - criteria:
-          - "<=1"
+          - "<=0.2"
     warning:
       - criteria:
-          - "<=0.5"
+          - "<=0.1"
   - sli: request_throughput
     displayName: "Request Throughput"
     pass:

--- a/quickstart/demo/slo.yaml
+++ b/quickstart/demo/slo.yaml
@@ -9,7 +9,7 @@ objectives:
     displayName: "HTTP Respone Time"
     pass:
       - criteria:
-          - "<=0.2"
+          - "<=0.4"
     warning:
       - criteria:
           - "<=0.1"


### PR DESCRIPTION
## This PR

The SLO file for the quickstart example and the podtatohead version used are out of sync. The [SLO file](https://github.com/keptn/examples/blob/master/quickstart/demo/slo.yaml#L12) checks for an HTTP response time of 1 second, but the [actual delay](https://github.com/jetzlstorfer/podtato-head/blob/main/podtato-server/podtatoserver.go#L83) of the used podatohead is only 200ms and does therefore not trigger the SLO criteria.

The PR fixes this problem by reducing the SLO time to 200ms.

### How to test

Run the [quickstart guide](https://keptn.sh/docs/quickstart/) using the new SLO file.

