### PR TITLE
fix: Use elevated token for checkout during (pre)release

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -19,6 +19,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
+          token: ${{ secrets.KEPTN_BOT_TOKEN }}
 
       - name: Set up Node.js
         uses: actions/setup-node@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
+          token: ${{ secrets.KEPTN_BOT_TOKEN }}
 
       - name: Set up Node.js
         uses: actions/setup-node@v2


### PR DESCRIPTION
### This PR
<!-- add the description of the PR here -->

- adds a different token to the checkout step during releases to be able to push the release later on in the pipeline

#### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Part of keptn/keptn#5817
