### PR TITLE
fix: Check if example directory already exists

### DIFF
--- a/quickstart/multistage-delivery.sh
+++ b/quickstart/multistage-delivery.sh
@@ -101,9 +101,10 @@ echo "git clone https://github.com/keptn/examples --single-branch"
 
 DIR="./examples"
 BOLD='\033[1m'
+NORMAL='\033[0m'
 if [ -d "$DIR" ]; then
   # Example directory already exists
-  echo -e "\n${BOLD}Example directory already exists in folder. Skipping download!"
+  echo -e "\n${BOLD}Example directory already exists in folder. Skipping download!${NORMAL}"
 else
   # Example Directory does not exist
   git clone https://github.com/keptn/examples --single-branch

--- a/quickstart/multistage-delivery.sh
+++ b/quickstart/multistage-delivery.sh
@@ -98,7 +98,17 @@ verify_helm_installation
 print_headline "Downloading demo resources"
 echo "This will create a local folder ./examples"
 echo "git clone https://github.com/keptn/examples --single-branch"
-git clone https://github.com/keptn/examples --single-branch
+
+DIR="./examples"
+BOLD='\033[1m'
+if [ -d "$DIR" ]; then
+  # Example directory already exists
+  echo -e "\n${BOLD}Example directory already exists in folder. Skipping download!"
+else
+  # Example Directory does not exist
+  git clone https://github.com/keptn/examples --single-branch
+fi
+
 cd examples/quickstart
 
 print_headline "Create a Keptn project"


### PR DESCRIPTION
Currently, when the `multistage-delivery.sh` script of the quickstarter example is run multiple times, it fails since the `examples` repository already exists.

```
fatal: destination path 'examples' already exists and is not an empty directory.
```

Now the existence of the directory gets checked before cloning the repository to remove the possibility of this error.

## Fixes
[Keptn.sh issue](https://github.com/keptn/keptn.github.io/issues/860)