### PR TITLE
fix: Use vanilla podtato-head images for quickstart

### DIFF
--- a/quickstart/automated-operations.sh
+++ b/quickstart/automated-operations.sh
@@ -66,7 +66,7 @@ keptn add-resource --project=$PROJECT --service=$SERVICE --stage=production --re
 wait_for_deployment_in_namespace "job-executor-service" "keptn"
 
 print_headline "Simulate Alert (Problem)"
-echo -e "{\"type\": \"sh.keptn.event.production.remediation.triggered\",\"specversion\":\"1.0\",\"source\":\"https:\/\/github.com\/keptn\/keptn\/prometheus-service\",\"id\": \"f2b878d3-03c0-4e8f-bc3f-454bc1b3d79d\",  \"time\": \"2019-06-07T07:02:15.64489Z\",  \"contenttype\": \"application\/json\", \"data\": {\"project\": \"podtatohead\",\"stage\": \"production\",\"service\": \"helloservice\",\"problem\": { \"problemTitle\": \"out_of_memory\",\"rootCause\": \"Response time degradation\"}}}" > remediation_trigger.json | keptn send event -f remediation_trigger.json
+echo -e "{\"type\": \"sh.keptn.event.production.remediation.triggered\",\"specversion\":\"1.0\",\"source\":\"https:\/\/github.com\/keptn-contrib\/prometheus-service\",\"id\": \"f2b878d3-03c0-4e8f-bc3f-454bc1b3d79d\",  \"time\": \"2019-06-07T07:02:15.64489Z\",  \"contenttype\": \"application\/json\", \"data\": {\"project\": \"podtatohead\",\"stage\": \"production\",\"service\": \"helloservice\",\"problem\": { \"problemTitle\": \"out_of_memory\",\"rootCause\": \"Response time degradation\"}}}" > remediation_trigger.json | keptn send event -f remediation_trigger.json
 
 print_headline "Have a look at the Keptn Bridge and explore the demo project"
 

--- a/quickstart/demo/jmeter/jmeter.conf.yaml
+++ b/quickstart/demo/jmeter/jmeter.conf.yaml
@@ -2,8 +2,8 @@
 spec_version: '0.1.0'
 workloads:
   - teststrategy: performance
-    vuser: 35
-    loopcount: 600
+    vuser: 30
+    loopcount: 150
     script: jmeter/load.jmx
     acceptederrorrate: 1.0
   - teststrategy: performance_light

--- a/quickstart/demo/prometheus/sli.yaml
+++ b/quickstart/demo/prometheus/sli.yaml
@@ -2,7 +2,7 @@
 spec_version: '1.0'
 indicators:
   http_response_time_seconds_main_page_sum: sum(rate(http_server_request_duration_seconds_sum{method="GET",route="/",status_code="200",job="$SERVICE-$PROJECT-$STAGE"}[$DURATION_SECONDS])/rate(http_server_request_duration_seconds_count{method="GET",route="/",status_code="200",job="$SERVICE-$PROJECT-$STAGE"}[$DURATION_SECONDS]))
-  failing_request: promhttp_metric_handler_requests_total{code!="200",job="$SERVICE-$PROJECT-$STAGE"}
-  http_requests_total_sucess: http_requests_total{status="success"}
+  failing_request: promhttp_metric_handler_requests_total{code!="200",job="$SERVICE-$PROJECT-$STAGE"}[$DURATION_SECONDS]
+  http_requests_total_sucess: http_requests_total{status="success",job="$SERVICE-$PROJECT-$STAGE"}
   go_routines: go_goroutines{job="$SERVICE-$PROJECT-$STAGE"}
-  request_throughput: sum(rate(http_requests_total{status="success"}[2m]))
+  request_throughput: sum(rate(http_requests_total{status="success",job="$SERVICE-$PROJECT-$STAGE"}[$DURATION_SECONDS]))

--- a/quickstart/demo/slo.yaml
+++ b/quickstart/demo/slo.yaml
@@ -24,7 +24,7 @@ objectives:
     key_sli: true
     pass:
       - criteria:
-          - "<=90"
+          - "<=30"
   - sli: failing_request
     displayName: "Failing Requests"
     pass:

--- a/quickstart/multistage-delivery.sh
+++ b/quickstart/multistage-delivery.sh
@@ -3,9 +3,9 @@ set -e
 
 PROJECT="podtatohead"
 SERVICE="helloservice"
-IMAGE="docker.io/jetzlstorfer/helloserver"
-VERSION=0.1.1
-SLOW_VERSION=0.1.2
+IMAGE="ghcr.io/podtato-head/podtatoserver"
+VERSION=v0.1.1
+SLOW_VERSION=v0.1.2
 
 #source <(curl -s https://raw.githubusercontent.com/keptn/keptn/0.8.5/test/utils.sh)
 
@@ -123,6 +123,8 @@ kubectl create ns monitoring
 helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
 helm install prometheus prometheus-community/prometheus --namespace monitoring --wait
 
+verify_test_step $? "Install prometheus failed"
+
 kubectl apply -f - <<EOF
 apiVersion: networking.k8s.io/v1
 kind: Ingress
@@ -148,8 +150,8 @@ verify_test_step $? "Applying Ingress for Prometheus failed"
 echo "Prometheus is available at http://prometheus.$INGRESS_IP.nip.io:$INGRESS_PORT "
 
 print_headline "Setting up Prometheus integration"
-kubectl apply -f https://raw.githubusercontent.com/keptn-contrib/prometheus-service/release-0.7.0/deploy/role.yaml -n monitoring
-kubectl apply -f https://raw.githubusercontent.com/keptn-contrib/prometheus-service/release-0.7.0/deploy/service.yaml 
+kubectl apply -f https://raw.githubusercontent.com/keptn-contrib/prometheus-service/release-0.7.1/deploy/role.yaml -n monitoring
+kubectl apply -f https://raw.githubusercontent.com/keptn-contrib/prometheus-service/release-0.7.1/deploy/service.yaml
 
 promsecretdata="url: http://prometheus-server.monitoring.svc.cluster.local:80"
 echo "kubectl create secret generic -n keptn prometheus-credentials-$PROJECT --from-literal=prometheus-credentials=$promsecretdata"


### PR DESCRIPTION
## This PR

**changes the quickstart guide using podtato-head as follows**

* Upgrade to prometheus-service 0.7.1
* Fix a typo in the `source` field when simulating an alert using prometheus
* Use vanilla (original) podtato-head images
* Change jmeter config in order to decrease the time needed for the performance test executed using JMeter
* Change SLI/SLO defnition to fit the vanilla (original) podtato-head-images


Fixes #213 

## Proof

### v0.1.1
![image](https://user-images.githubusercontent.com/56065213/144846978-d5c1e021-89ca-40bd-9fc6-1d2dcc66805f.png)

![image](https://user-images.githubusercontent.com/56065213/144846999-24db5850-9db7-4d51-b35a-444f0722e438.png)

### v0.1.2 (slow version)
![image](https://user-images.githubusercontent.com/56065213/144847048-e5eb70a6-9c29-43f6-885b-1156e2904a97.png)

![image](https://user-images.githubusercontent.com/56065213/144847070-9005c3fb-b5ad-4073-891b-6a1abbd9e9d1.png)

### simulated remediation

![image](https://user-images.githubusercontent.com/56065213/144847119-2118b7ac-2745-4114-a9e9-fb8dbd148162.png)


