### PR TITLE
fix: Update Quickstart SLI config to produce proper Configuration YAML in the Prometheus Service

### DIFF
--- a/quickstart/demo/slo.yaml
+++ b/quickstart/demo/slo.yaml
@@ -29,7 +29,7 @@ objectives:
     displayName: "Failing Requests"
     pass:
       - criteria:
-          - "< 10"
+          - "<10"
 total_score:
   pass: "90%"
   warning: "75%"


### PR DESCRIPTION
Fixes https://github.com/keptn/keptn.github.io/issues/984 in the quickstart guide

<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

- Looks like there is a regression in the Prometheus service which impacts proper config generation if the SLI check contains spaces. This PR fixes it. https://github.com/keptn/keptn.github.io/issues/984

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->
- https://github.com/keptn/keptn.github.io/issues/984


