### PR TITLE
fix: Fixed retrying bug even if opening bridge is successful

### DIFF
--- a/quickstart/expose-keptn.sh
+++ b/quickstart/expose-keptn.sh
@@ -44,9 +44,9 @@ function wait_for_deployment_in_namespace() {
         echo "Found deployment ${DEPLOYMENT} in namespace ${NAMESPACE}: ${DEPLOYMENT_LIST}"
         break
       else
-          RETRY=$((RETRY+1))
-          echo "Retry: ${RETRY}/${RETRY_MAX} - Unsufficient replicas for deployment - waiting 15s for deployment ${DEPLOYMENT} in namespace ${NAMESPACE}"
-          sleep 15
+        RETRY=$((RETRY+1))
+        echo "Retry: ${RETRY}/${RETRY_MAX} - Unsufficient replicas for deployment - waiting 15s for deployment ${DEPLOYMENT} in namespace ${NAMESPACE}"
+        sleep 15
       fi
     fi
   done
@@ -122,10 +122,10 @@ do
   if [ ${http_code} -eq 200 ]; then
     echo "Attempting to open Keptn bridge on http://$INGRESS_IP.nip.io:$INGRESS_PORT/bridge"
 
-     if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+    if [[ "$OSTYPE" == "linux-gnu"* ]]; then
       OPEN=('xdg-open')
     else
-        OPEN=('open')
+      OPEN=('open')
     fi
 
     if ! command -v "${OPEN[@]}" &> /dev/null
@@ -135,6 +135,7 @@ do
       break
     else
       "${OPEN[@]}" http://$INGRESS_IP.nip.io:$INGRESS_PORT/bridge
+      break
     fi
   fi
   echo "Keptn bridge not yet available, waiting $SLEEP_TIME seconds and then trying again"


### PR DESCRIPTION
## This PR

- Fixes bug inside `expose-keptn.sh` file that retries the opening of the Keptn bridge even though it was already open. This is due to a missing break statement.
-  Also fixes the some minor formatting issues (wrong spacing)

### How to test

Run `curl -SL https://raw.githubusercontent.com/keptn/examples/master/quickstart/expose-keptn.sh | bash`

