### PR TITLE
fix: removed jq dependency

### DIFF
--- a/istio-configuration/configure-istio.sh
+++ b/istio-configuration/configure-istio.sh
@@ -18,7 +18,7 @@ fi
 echo "External IP for istio-ingressgateway is ${INGRESS_IP}, creating configmaps..."
 
 K8S_VERSION=$(kubectl version -ojson)
-K8S_VERSION_MINOR=$(echo "$K8S_VERSION" | jq -r .serverVersion.minor)
+K8S_VERSION_MINOR=$(echo "$K8S_VERSION" | grep 'minor' | tail -1 | sed 's/^.*: //' | sed 's/^"\(.*\)".*/\1/')
 
 if [[ "$K8S_VERSION_MINOR" < "19" ]]
 then

--- a/quickstart/expose-keptn.sh
+++ b/quickstart/expose-keptn.sh
@@ -73,7 +73,7 @@ SLEEP_TIME=5
 print_headline "Configuring Ingress for your local installation"
 
 K8S_VERSION=$(kubectl version -ojson)
-K8S_VERSION_MINOR=$(echo "$K8S_VERSION" | jq -r .serverVersion.minor)
+K8S_VERSION_MINOR=$(echo "$K8S_VERSION" | grep 'minor' | tail -1 | sed 's/^.*: //' | sed 's/^"\(.*\)".*/\1/')
 
 if [[ "$K8S_VERSION_MINOR" < "19" ]]
 then

--- a/quickstart/multistage-delivery.sh
+++ b/quickstart/multistage-delivery.sh
@@ -137,7 +137,7 @@ helm install prometheus prometheus-community/prometheus --namespace monitoring -
 verify_test_step $? "Install prometheus failed"
 
 K8S_VERSION=$(kubectl version -ojson)
-K8S_VERSION_MINOR=$(echo "$K8S_VERSION" | jq -r .serverVersion.minor)
+K8S_VERSION_MINOR=$(echo "$K8S_VERSION" | grep 'minor' | tail -1 | sed 's/^.*: //' | sed 's/^"\(.*\)".*/\1/')
 
 if [[ "$K8S_VERSION_MINOR" < "19" ]]
 then


### PR DESCRIPTION
## This PR

Removes the need to have jq installed to run [istio-configuration/configure-istio.sh](https://github.com/keptn/examples/blob/4e16dc19a26b4f17822f9c85509e084b1e974c35/istio-configuration/configure-istio.sh), [quickstart/expose-keptn.sh](https://github.com/keptn/examples/blob/4e16dc19a26b4f17822f9c85509e084b1e974c35/quickstart/expose-keptn.sh) and [quickstart/multistage-delivery.sh](https://github.com/keptn/examples/blob/4e16dc19a26b4f17822f9c85509e084b1e974c35/quickstart/multistage-delivery.sh) as described in #223

### Related Issues

Fixes #223


