### PR TITLE
feat: Add default `dynatrace/dynatrace.conf.yaml`

### DIFF
--- a/onboarding-carts/dynatrace/dynatrace.conf.yaml
+++ b/onboarding-carts/dynatrace/dynatrace.conf.yaml
@@ -1,0 +1,2 @@
+spec_version: '0.1.0'
+dtCreds: dynatrace


### PR DESCRIPTION
Signed-off-by: Arthur Pitman <arthur.pitman@dynatrace.com>

## This PR
- Adds a default `dynatrace/dynatrace.conf.yaml` file, intended for use in the Keptn Full Tour on Dynatrace tutorial.

### Related Issues
- Due to the changes introduced in https://github.com/keptn-contrib/dynatrace-service/pull/612, a  `dynatrace/dynatrace.conf.yaml` file is always required to use the dynatrace-service.