### PR TITLE
feat: Use latest prometheus-service SLI placeholders

### DIFF
--- a/onboarding-carts/sli-config-prometheus-bg.yaml
+++ b/onboarding-carts/sli-config-prometheus-bg.yaml
@@ -1,6 +1,0 @@
----
-spec_version: '1.0'
-indicators:
-  response_time_p50: histogram_quantile(0.5, sum by(le) (rate(http_response_time_milliseconds_bucket{handler="ItemsController.addToCart",job="$SERVICE-$PROJECT-$STAGE-canary"}[$DURATION_SECONDS])))
-  response_time_p90: histogram_quantile(0.9, sum by(le) (rate(http_response_time_milliseconds_bucket{handler="ItemsController.addToCart",job="$SERVICE-$PROJECT-$STAGE-canary"}[$DURATION_SECONDS])))
-  response_time_p95: histogram_quantile(0.95, sum by(le) (rate(http_response_time_milliseconds_bucket{handler="ItemsController.addToCart",job="$SERVICE-$PROJECT-$STAGE-canary"}[$DURATION_SECONDS])))

--- a/onboarding-carts/sli-config-prometheus-selfhealing.yaml
+++ b/onboarding-carts/sli-config-prometheus-selfhealing.yaml
@@ -1,6 +1,0 @@
----
-spec_version: '1.0'
-indicators:
-  response_time_p50: histogram_quantile(0.5, sum by(le) (rate(http_response_time_milliseconds_bucket{handler="ItemsController.addToCart",job="$SERVICE-$PROJECT-$STAGE-primary"}[3m])))
-  response_time_p90: histogram_quantile(0.9, sum by(le) (rate(http_response_time_milliseconds_bucket{handler="ItemsController.addToCart",job="$SERVICE-$PROJECT-$STAGE-primary"}[3m])))
-  response_time_p95: histogram_quantile(0.95, sum by(le) (rate(http_response_time_milliseconds_bucket{handler="ItemsController.addToCart",job="$SERVICE-$PROJECT-$STAGE-primary"}[3m])))

--- a/onboarding-carts/sli-config-prometheus.yaml
+++ b/onboarding-carts/sli-config-prometheus.yaml
@@ -1,0 +1,6 @@
+---
+spec_version: '1.0'
+indicators:
+  response_time_p50: histogram_quantile(0.5, sum by(le) (rate(http_response_time_milliseconds_bucket{handler="ItemsController.addToCart",job="$SERVICE-$PROJECT-$STAGE-$DEPLOYMENT"}[$DURATION_SECONDS])))
+  response_time_p90: histogram_quantile(0.9, sum by(le) (rate(http_response_time_milliseconds_bucket{handler="ItemsController.addToCart",job="$SERVICE-$PROJECT-$STAGE-$DEPLOYMENT"}[$DURATION_SECONDS])))
+  response_time_p95: histogram_quantile(0.95, sum by(le) (rate(http_response_time_milliseconds_bucket{handler="ItemsController.addToCart",job="$SERVICE-$PROJECT-$STAGE-$DEPLOYMENT"}[$DURATION_SECONDS])))


### PR DESCRIPTION
## This PR

- Updates prometheus-services SLI config files for the onboarding-carts example

**Reason**: With [Prometheus-Service 0.7.3](https://github.com/keptn-contrib/prometheus-service/releases/tag/0.7.3) we are finally able to use `$DEPLOYMENT` in the SLI config, and no longer need multiple SLI files.

**IMPORTANT NOTE**: This also needs to be reflected in keptn/tutorials. Once this PR is merged and released (e.g., keptn/exampels@0.14.0), we need to update tutorials, e.g.:
```
keptn add-resource --project=sockshop --stage=staging --service=carts --resource=sli-config-prometheus-bg.yaml --resourceUri=prometheus/sli.yaml 
```
changes to
```
keptn add-resource --project=sockshop --stage=staging --service=carts --resource=sli-config-prometheus.yaml --resourceUri=prometheus/sli.yaml 
```

