### PR TITLE
Fix Quickstart

### DIFF
--- a/quickstart/automated-operations.sh
+++ b/quickstart/automated-operations.sh
@@ -58,9 +58,14 @@ keptn add-resource --project=$PROJECT --stage=production --service=$SERVICE --re
 echo "Adding Remediation Configuration"
 keptn add-resource --project=$PROJECT --stage=production --service=$SERVICE --resource=./demo/remediation.yaml --resourceUri=remediation.yaml
 
-print_headline "Deploy Job Executor"
+jes_is_installed=$(kubectl -n keptn get deployment job-executor-service --ignore-not-found)
+if [[ $jes_is_installed == "" ]]; then
+  print_headline "Deploy Job Executor"
+  kubectl apply -f ./demo/job/job-executor.yaml
+else
+  print_headline "Job Executor Already Deployed. Skipping Deployment. Will Add Config."
+fi
 
-kubectl apply -f ./demo/job/job-executor.yaml
 keptn add-resource --project=$PROJECT --service=$SERVICE --stage=production --resource=./demo/job/config.yaml --resourceUri=job/config.yaml
 
 wait_for_deployment_in_namespace "job-executor-service" "keptn"

--- a/quickstart/demo/job/job-executor.yaml
+++ b/quickstart/demo/job/job-executor.yaml
@@ -8,18 +8,21 @@ metadata:
 spec:
   selector:
     matchLabels:
-      run: job-executor-service
+      app.kubernetes.io/name: distributor
+      app.kubernetes.io/instance: keptn
   replicas: 1
   template:
     metadata:
       labels:
-        run: job-executor-service
-        app.kubernetes.io/name: job-executor-service
-        app.kubernetes.io/version: 0.1.4
+        app.kubernetes.io/name: distributor
+        app.kubernetes.io/instance: keptn
+        app.kubernetes.io/part-of: keptn-keptn
+        app.kubernetes.io/component: control-plane
+        app.kubernetes.io/version: develop
     spec:
       containers:
         - name: job-executor-service
-          image: jbraeuer/job-executor-service:0.1.4.1
+          image: keptncontrib/job-executor-service:0.1.7
           ports:
             - containerPort: 8080
           resources:
@@ -37,7 +40,7 @@ spec:
             - name: JOB_NAMESPACE
               value: 'keptn'
             - name: INIT_CONTAINER_IMAGE
-              value: 'keptnsandbox/job-executor-service-initcontainer:0.1.4'
+              value: 'keptncontrib/job-executor-service-initcontainer:0.1.7'
             - name: DEFAULT_RESOURCE_LIMITS_CPU
               value: "1"
             - name: DEFAULT_RESOURCE_LIMITS_MEMORY
@@ -49,7 +52,7 @@ spec:
             - name: ALWAYS_SEND_FINISHED_EVENT
               value: "false"
         - name: distributor
-          image: keptn/distributor:0.9.2
+          image: keptn/distributor:0.13.2
           livenessProbe:
             httpGet:
               path: /health
@@ -61,11 +64,11 @@ spec:
             - containerPort: 8080
           resources:
             requests:
-              memory: "32Mi"
-              cpu: "50m"
+              memory: "16Mi"
+              cpu: "25m"
             limits:
-              memory: "128Mi"
-              cpu: "500m"
+              memory: "32Mi"
+              cpu: "100m"
           env:
             - name: PUBSUB_URL
               value: 'nats://keptn-nats-cluster'
@@ -78,6 +81,10 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: 'metadata.labels[''app.kubernetes.io/version'']'
+            - name: LOCATION
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.labels['app.kubernetes.io/component']
             - name: K8S_DEPLOYMENT_NAME
               valueFrom:
                 fieldRef:


### PR DESCRIPTION
This PR will fix the Quickstart tutorial as mentioned in #227 

## Lessons learned

1. The auto remediation use case cannot be run without the multi-stage delivery because `podtatohead-production` won't exist. Docs should be updated to mention that the flow is: `Keptn hello world > multi stage delivery > auto remediation`

## Things Fixed
- [x] Updated images to latest ones & now uses `keptncontrib` repo images not images stored in a @johannes-b's repo.
- [x] Added a check in autoremediation shell script to only install JES if it doesn't already exist

## Outstanding Items Before Merging PR
- [ ] Currently the JES pod fails with `The connection to the server localhost:8080 was refused` @christian-kreuzberger-dtx will probably immediately spot the issue that I'm missing :)

```
{
  "data": {
    "message": "Job job-executor-service-job-6e3b00dc-5586-45d7-9ce6-635c-1 failed: job job-executor-service-job-6e3b00dc-5586-45d7-9ce6-635c-1 failed. Reason: BackoffLimitExceeded, Message: Job has reached the specified backoff limit\n\nLogs: \nThe connection to the server localhost:8080 was refused - did you specify the right host or port?\n",
    "project": "podtatohead",
    "result": "fail",
    "service": "helloservice",
    "stage": "production",
    "status": "errored"
  },
  "id": "4a31e0f7-43c7-448a-af8b-02bb069489e4",
  "shkeptncontext": "2461cd3f-5c4f-48bc-8063-f32ba5f7f5cb",
  "shkeptnspecversion": "0.2.4",
  "source": "shipyard-controller",
  "specversion": "1.0",
  "time": "2022-03-14T09:53:43.722Z",
  "triggeredid": "c063b994-dad8-4e0c-a565-62644dca9f0c",
  "type": "sh.keptn.event.production.remediation.finished"
}
```
