### PR TITLE
Adapt the Prometheus Quickstart to the breaking chance in 0.14.1

### DIFF
--- a/quickstart/demo/job/job-executor.yaml
+++ b/quickstart/demo/job/job-executor.yaml
@@ -22,7 +22,7 @@ spec:
     spec:
       containers:
         - name: job-executor-service
-          image: keptncontrib/job-executor-service:0.1.7
+          image: keptncontrib/job-executor-service:0.1.8
           ports:
             - containerPort: 8080
           resources:
@@ -52,7 +52,7 @@ spec:
             - name: ALWAYS_SEND_FINISHED_EVENT
               value: "false"
         - name: distributor
-          image: keptn/distributor:0.13.2
+          image: keptn/distributor:0.14.1
           livenessProbe:
             httpGet:
               path: /health
@@ -70,8 +70,6 @@ spec:
               memory: "32Mi"
               cpu: "100m"
           env:
-            - name: PUBSUB_URL
-              value: 'nats://keptn-nats-cluster'
             - name: PUBSUB_TOPIC
               value: 'sh.keptn.>'
             - name: PUBSUB_RECIPIENT


### PR DESCRIPTION
Adapts the demo to 0.14.1 according to https://keptn.sh/docs/0.14.x/operate/upgrade/#upgrade-from-keptn-0-13-x-to-keptn-0-14-x

CC @stacscribe @agardnerIT @henrikrexed