### PR TITLE
fix: Update quickstart example to use prometheus-service 0.8.0

### DIFF
--- a/quickstart/multistage-delivery.sh
+++ b/quickstart/multistage-delivery.sh
@@ -186,7 +186,7 @@ echo "Prometheus is available at http://prometheus.$INGRESS_IP.nip.io:$INGRESS_P
 
 print_headline "Setting up Prometheus integration"
 
-PROMETHEUS_SERVICE_VERSION=0.7.2
+PROMETHEUS_SERVICE_VERSION=0.8.0
 
 helm install -n keptn prometheus-service https://github.com/keptn-contrib/prometheus-service/releases/download/${PROMETHEUS_SERVICE_VERSION}/prometheus-service-${PROMETHEUS_SERVICE_VERSION}.tgz --wait
 kubectl apply -f https://raw.githubusercontent.com/keptn-contrib/prometheus-service/${PROMETHEUS_SERVICE_VERSION}/deploy/role.yaml -n monitoring


### PR DESCRIPTION
As per https://cloud-native.slack.com/archives/C017GAX90GM/p1652709824176979 we were notified that the quickstart example does not work anymore with prometheus-service crashing.

This is due to the fact that the quickstart uses the latest Keptn version (e.g., 0.15.0), but prometheus-service 0.7.2 is not comptabiel with that (breaking change introduced by Keptn 0.14.x).

With this PR, I'm setting the [prometheus-service version to 0.8.0](https://github.com/keptn-contrib/prometheus-service/releases/tag/0.8.0), which addresses this breaking change.